### PR TITLE
Implement beginning-end ignore optimization

### DIFF
--- a/Tests/ListDiffTests.cs
+++ b/Tests/ListDiffTests.cs
@@ -26,6 +26,28 @@ namespace ListDiffTests
 			Assert.Equal (expectedDiff, diff.ToString ());
 		}
 
+		[Theory]
+		[InlineData (1000)]
+		[InlineData (10000)]
+		[InlineData (100000)]
+		public void DiffMiddleModificationOfLongList (int listSize)
+		{
+			var sb = new System.Text.StringBuilder ();
+			for (int i = 0; i < listSize / 10; i++) {
+				sb.Append ("0123456789");
+			}
+
+			var original = sb.ToString ();
+			var middleIndex = original.Length / 2;
+			var middleItem = original[middleIndex];
+			var modified = sb.ToString ().Remove (middleIndex, 1);
+			var expectedDiff = modified.Insert (middleIndex, string.Format("-({0})", middleItem));
+
+			var diff = original.Diff (modified);
+
+			Assert.Equal (expectedDiff, diff.ToString ());
+		}
+
 		[Fact]
 		public void Insert ()
 		{


### PR DESCRIPTION
Improve efficiency by [reducing problem set](https://en.wikipedia.org/wiki/Longest_common_subsequence_problem#Reduce_the_problem_set) and therefore the C matrix.
This helps to significantly reduce cpu time and memory consumption for comparing big lists with matching items at the beginning and the end of them.
Includes test to check and debug such cases. Without the optimization it fails due to OutOfMemoryException.
Resolves #1