### PR TITLE
Add .NET Standard 2.0 target

### DIFF
--- a/ListDiff/ListDiff.csproj
+++ b/ListDiff/ListDiff.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard1.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugSymbols>true</DebugSymbols>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DocumentationFile>bin\Release\netstandard1.0\ListDiff.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\$(TargetFramework)\ListDiff.xml</DocumentationFile>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This PR adds .NET Standard 2.0 as an _additional target_. The rationale is laid out in the [Cross-platform targeting](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting#net-standard) section of the [Open-source library guidance](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/):

> All platforms supporting .NET Standard 2.0 will use the `netstandard2.0` target and benefit from having a smaller package graph while older platforms will still work and fall back to using the `netstandard1.x` target.

The complete and relevant guidelines are:

> ✔️ DO start with including a `netstandard2.0` target.
>
> > Most general-purpose libraries should not need APIs outside of .NET Standard 2.0. .NET Standard 2.0 is supported by all modern platforms and is the recommended way to support multiple platforms with one target.
>
> ❌ AVOID including a `netstandard1.x` target.
>
> > .NET Standard 1.x is distributed as a granular set of NuGet packages, which creates a large package dependency graph and results in developers downloading a lot of packages when building. Modern .NET platforms, including .NET Framework 4.6.1, UWP and Xamarin, all support .NET Standard 2.0. You should only target .NET Standard 1.x if you specifically need to target an older platform.
>
> ✔️ DO include a `netstandard2.0` target if you require a `netstandard1.x` target.
>
> > All platforms supporting .NET Standard 2.0 will use the `netstandard2.0` target and benefit from having a smaller package graph while older platforms will still work and fall back to using the `netstandard1.x` target.
