### PR TITLE
Separate core algo into a more generic version

### DIFF
--- a/ListDiff/Diff.cs
+++ b/ListDiff/Diff.cs
@@ -26,23 +26,38 @@ using System.Linq;
 
 namespace ListDiff
 {
+	/// <summary>
+	/// TODO
+	/// </summary>
 	static partial class DiffModule
 	{
+		/// <summary>
+		/// TODO
+		/// </summary>
 		public static List<(A, T, T)> Diff<T, A> (IEnumerable<T> source, IEnumerable<T> destination,
 		                                          A update, A add, A remove) =>
 			Diff (source, destination, update, add, remove, out _);
 
+		/// <summary>
+		/// TODO
+		/// </summary>
 		public static List<(A, T, T)> Diff<T, A> (IEnumerable<T> source, IEnumerable<T> destination,
 												  A update, A add, A remove,
 												  out bool containsOnlyUpdates) =>
 			Diff (source, destination, (s, d) => EqualityComparer<T>.Default.Equals (s, d),
 			      update, add, remove, out containsOnlyUpdates);
 
+		/// <summary>
+		/// TODO
+		/// </summary>
 		public static List<(A, S, D)> Diff<S, D, A> (IEnumerable<S> source, IEnumerable<D> destination,
 		                                             Func<S, D, bool> match,
 		                                             A update, A add, A remove) =>
 			Diff (source, destination, match, update, add, remove, out _);
 
+		/// <summary>
+		/// TODO
+		/// </summary>
 		public static List<(A, S, D)> Diff<S, D, A> (IEnumerable<S> source, IEnumerable<D> destination,
 		                                             Func<S, D, bool> match,
 		                                             A update, A add, A remove,
@@ -52,21 +67,33 @@ namespace ListDiff
 											  s => (remove, s, default),
 											  out containsOnlyUpdates);
 
+		/// <summary>
+		/// TODO
+		/// </summary>
 		public static List<R> Diff<T, R> (IEnumerable<T> source, IEnumerable<T> destination,
 		                                  Func<T, T, R> updateResult, Func<T, R> addResult, Func<T, R> removeResult) =>
 			Diff (source, destination, updateResult, addResult, removeResult, out _);
 
+		/// <summary>
+		/// TODO
+		/// </summary>
 		public static List<R> Diff<T, R> (IEnumerable<T> source, IEnumerable<T> destination,
 		                                  Func<T, T, R> updateResult, Func<T, R> addResult, Func<T, R> removeResult,
 		                                  out bool containsOnlyUpdates) =>
 			Diff (source, destination, (s, d) => EqualityComparer<T>.Default.Equals (s, d),
 			      updateResult, addResult, removeResult, out containsOnlyUpdates);
 
+		/// <summary>
+		/// TODO
+		/// </summary>
 		public static List<R> Diff<S, D, R> (IEnumerable<S> source, IEnumerable<D> destination,
 											 Func<S, D, bool> match,
 											 Func<S, D, R> updateResult, Func<D, R> addResult, Func<S, R> removeResult) =>
 			Diff (source, destination, match, updateResult, addResult, removeResult, out _);
 
+		/// <summary>
+		/// TODO
+		/// </summary>
 		public static List<R> Diff<S, D, R> (IEnumerable<S> source, IEnumerable<D> destination,
 		                                     Func<S, D, bool> match,
 											 Func<S, D, R> updateResult, Func<D, R> addResult, Func<S, R> removeResult,

--- a/ListDiff/Diff.cs
+++ b/ListDiff/Diff.cs
@@ -26,7 +26,7 @@ using System.Linq;
 
 namespace ListDiff
 {
-	static partial class ListDiff
+	static partial class DiffModule
 	{
 		public static List<(A, T, T)> Diff<T, A> (IEnumerable<T> source, IEnumerable<T> destination,
 		                                          A update, A add, A remove) =>

--- a/ListDiff/Diff.cs
+++ b/ListDiff/Diff.cs
@@ -1,0 +1,151 @@
+﻿//
+// Copyright (c) Krueger Systems, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ListDiff
+{
+	static partial class ListDiff
+	{
+		public static List<(A, T, T)> Diff<T, A> (IEnumerable<T> source, IEnumerable<T> destination,
+		                                          A update, A add, A remove) =>
+			Diff (source, destination, update, add, remove, out _);
+
+		public static List<(A, T, T)> Diff<T, A> (IEnumerable<T> source, IEnumerable<T> destination,
+												  A update, A add, A remove,
+												  out bool containsOnlyUpdates) =>
+			Diff (source, destination, (s, d) => EqualityComparer<T>.Default.Equals (s, d),
+			      update, add, remove, out containsOnlyUpdates);
+
+		public static List<(A, S, D)> Diff<S, D, A> (IEnumerable<S> source, IEnumerable<D> destination,
+		                                             Func<S, D, bool> match,
+		                                             A update, A add, A remove) =>
+			Diff (source, destination, match, update, add, remove, out _);
+
+		public static List<(A, S, D)> Diff<S, D, A> (IEnumerable<S> source, IEnumerable<D> destination,
+		                                             Func<S, D, bool> match,
+		                                             A update, A add, A remove,
+		                                             out bool containsOnlyUpdates) =>
+			Diff (source, destination, match, (s, d) => (update, s, d),
+											  d => (add, default, d),
+											  s => (remove, s, default),
+											  out containsOnlyUpdates);
+
+		public static List<R> Diff<T, R> (IEnumerable<T> source, IEnumerable<T> destination,
+		                                  Func<T, T, R> updateResult, Func<T, R> addResult, Func<T, R> removeResult) =>
+			Diff (source, destination, updateResult, addResult, removeResult, out _);
+
+		public static List<R> Diff<T, R> (IEnumerable<T> source, IEnumerable<T> destination,
+		                                  Func<T, T, R> updateResult, Func<T, R> addResult, Func<T, R> removeResult,
+		                                  out bool containsOnlyUpdates) =>
+			Diff (source, destination, (s, d) => EqualityComparer<T>.Default.Equals (s, d),
+			      updateResult, addResult, removeResult, out containsOnlyUpdates);
+
+		public static List<R> Diff<S, D, R> (IEnumerable<S> source, IEnumerable<D> destination,
+											 Func<S, D, bool> match,
+											 Func<S, D, R> updateResult, Func<D, R> addResult, Func<S, R> removeResult) =>
+			Diff (source, destination, match, updateResult, addResult, removeResult, out _);
+
+		public static List<R> Diff<S, D, R> (IEnumerable<S> source, IEnumerable<D> destination,
+		                                     Func<S, D, bool> match,
+											 Func<S, D, R> updateResult, Func<D, R> addResult, Func<S, R> removeResult,
+											 out bool containsOnlyUpdates)
+		{
+			if (source == null) throw new ArgumentNullException (nameof (source));
+			if (destination == null) throw new ArgumentNullException (nameof (destination));
+			if (match == null) throw new ArgumentNullException (nameof (match));
+
+			IList<S> x = source as IList<S> ?? source.ToArray ();
+			IList<D> y = destination as IList<D> ?? destination.ToArray ();
+
+			var actions = new List<R> ();
+
+			var m = x.Count;
+			var n = y.Count;
+
+			var start = 0;
+
+			while (start < m && start < n && match (x[start], y[start])) {
+				start++;
+			}
+
+			while (start < m && start < n && match (x[m - 1], y[n - 1])) {
+				m--;
+				n--;
+			}
+
+			//
+			// Construct the C matrix
+			//
+			var c = new int[m - start + 1, n - start + 1];
+			for (var i = 1; i <= m - start; i++) {
+				for (var j = 1; j <= n - start; j++) {
+					if (match (x[i - 1], y[j - 1])) {
+						c[i, j] = c[i - 1, j - 1] + 1;
+					}
+					else {
+						c[i, j] = Math.Max (c[i, j - 1], c[i - 1, j]);
+					}
+				}
+			}
+
+			//
+			// Generate the actions
+			//
+			for (int i = 0; i < start; i++) {
+				actions.Add (updateResult (x[i], y[i]));
+			}
+
+			var varContainsOnlyUpdates = true;
+			GenDiff (m, n);
+
+			for (int i = 0; i < x.Count - m; i++) {
+				actions.Add (updateResult (x[m + i], y[n + i]));
+			}
+
+			containsOnlyUpdates = varContainsOnlyUpdates;
+			return actions;
+
+			void GenDiff (int i, int j)
+			{
+				if (i > start && j > start && match (x[i - 1], y[j - 1])) {
+					GenDiff (i - 1, j - 1);
+					actions.Add (updateResult (x[i - 1], y[j - 1]));
+				}
+				else {
+					if (j > start && (i == start || c[i - start, j - start - 1] >= c[i - start - 1, j - start])) {
+						GenDiff (i, j - 1);
+						varContainsOnlyUpdates = false;
+						actions.Add (addResult (y[j - 1]));
+					}
+					else if (i > start && (j == start || c[i - start, j - start - 1] < c[i - start - 1, j - start])) {
+						GenDiff (i - 1, j);
+						varContainsOnlyUpdates = false;
+						actions.Add (removeResult (x[i - 1]));
+					}
+				}
+			}
+		}
+	}
+}

--- a/ListDiff/ListDiff.cs
+++ b/ListDiff/ListDiff.cs
@@ -23,6 +23,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using static ListDiff.DiffModule;
 
 namespace ListDiff
 {
@@ -135,11 +136,11 @@ namespace ListDiff
 		/// <param name="match">Predicate used to match source and destination items</param>
 		public ListDiff (IEnumerable<S> source, IEnumerable<D> destination, Func<S, D, bool> match)
 		{
-			Actions = ListDiff.Diff (source, destination, match,
-			                         (s, d) => new ListDiffAction<S, D> (ListDiffActionType.Update, s, d),
-									 d      => new ListDiffAction<S, D> (ListDiffActionType.Add, default, d),
-									 s      => new ListDiffAction<S, D> (ListDiffActionType.Remove, s, default),
-									 out var containsOnlyUpdates);
+			Actions = Diff (source, destination, match,
+			                (s, d) => new ListDiffAction<S, D> (ListDiffActionType.Update, s, d),
+							d      => new ListDiffAction<S, D> (ListDiffActionType.Add, default, d),
+							s      => new ListDiffAction<S, D> (ListDiffActionType.Remove, s, default),
+							out var containsOnlyUpdates);
 			ContainsOnlyUpdates = containsOnlyUpdates;
 		}
 
@@ -296,5 +297,5 @@ namespace ListDiff
 		}
 	}
 
-	public partial class ListDiff {}
+	public partial class DiffModule {}
 }

--- a/ListDiff/ListDiff.csproj
+++ b/ListDiff/ListDiff.csproj
@@ -11,4 +11,8 @@
     <DocumentationFile>bin\Release\netstandard1.0\ListDiff.xml</DocumentationFile>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0'">
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+  </ItemGroup>
+
 </Project>

--- a/Tests/ListDiffTests.cs
+++ b/Tests/ListDiffTests.cs
@@ -22,8 +22,13 @@ namespace ListDiffTests
 		[InlineData ("abc", "", "-(a)-(b)-(c)")]
 		public void SimpleCases (string left, string right, string expectedDiff)
 		{
-			var diff = left.Diff (right);
-			Assert.Equal (expectedDiff, diff.ToString ());
+			var diff1 = left.Diff (right);
+
+			Assert.Equal (expectedDiff, diff1.ToString ());
+
+			var diff2 = ListDiff.ListDiff.Diff (left, right, (s, _) => s.ToString (), d => $"+({d})", s => $"-({s})");
+
+			Assert.Equal (expectedDiff, string.Join (string.Empty, diff2));
 		}
 
 		[Theory]
@@ -43,9 +48,13 @@ namespace ListDiffTests
 			var modified = sb.ToString ().Remove (middleIndex, 1);
 			var expectedDiff = modified.Insert (middleIndex, string.Format("-({0})", middleItem));
 
-			var diff = original.Diff (modified);
+			var diff1 = original.Diff (modified);
 
-			Assert.Equal (expectedDiff, diff.ToString ());
+			Assert.Equal (expectedDiff, diff1.ToString ());
+
+			var diff2 = ListDiff.ListDiff.Diff (original, modified, (s, _) => s.ToString (), d => $"+({d})", s => $"-({s})");
+
+			Assert.Equal (expectedDiff, string.Join (string.Empty, diff2));
 		}
 
 		[Fact]

--- a/Tests/ListDiffTests.cs
+++ b/Tests/ListDiffTests.cs
@@ -1,4 +1,5 @@
 using ListDiff;
+using static ListDiff.DiffModule;
 using Xunit;
 
 namespace ListDiffTests
@@ -26,7 +27,7 @@ namespace ListDiffTests
 
 			Assert.Equal (expectedDiff, diff1.ToString ());
 
-			var diff2 = ListDiff.ListDiff.Diff (left, right, (s, _) => s.ToString (), d => $"+({d})", s => $"-({s})");
+			var diff2 = Diff (left, right, (s, _) => s.ToString (), d => $"+({d})", s => $"-({s})");
 
 			Assert.Equal (expectedDiff, string.Join (string.Empty, diff2));
 		}
@@ -52,7 +53,7 @@ namespace ListDiffTests
 
 			Assert.Equal (expectedDiff, diff1.ToString ());
 
-			var diff2 = ListDiff.ListDiff.Diff (original, modified, (s, _) => s.ToString (), d => $"+({d})", s => $"-({s})");
+			var diff2 = Diff (original, modified, (s, _) => s.ToString (), d => $"+({d})", s => $"-({s})");
 
 			Assert.Equal (expectedDiff, string.Join (string.Empty, diff2));
 		}


### PR DESCRIPTION
I would have opened an issue first but some ideas and benefits are easier to demonstrate as a PR and working example, so here goes…

This PR primarily separates the diff algorithm from supporting types `ListDiffAction<,>`, `ListDiffActionType` and `ListDiff<,>` and renders it even more generic so that it can stand and be used on its own; this leads to many benefits.

First and foremost, the core function becomes very generic:

```c#
List<R> Diff<S, D, R> (IEnumerable<S> source, IEnumerable<D> destination,
                       Func<S, D, bool> match,
                       Func<S, D, R> updateResult,
                       Func<D, R> addResult,
                       Func<S, R> removeResult,
                       out bool containsOnlyUpdates)
```

The 3 functions `updateResult`, `addResult` and `removeResult` project the result elements such that the function can return a simple list (`List<>`) of those results. The shape of `R` is now up to the caller based on relevant inputs.

The constructor of `ListDiff<,>` has been updated to use it as follows:

```c#
Actions = Diff (source, destination, match,
                (s, d) => new ListDiffAction<S, D> (ListDiffActionType.Update, s, d),
                d      => new ListDiffAction<S, D> (ListDiffActionType.Add, default, d),
                s      => new ListDiffAction<S, D> (ListDiffActionType.Remove, s, default),
                out var containsOnlyUpdates)
```

The are several other overloads added for convenience. For example, when source and destination elements are the same some type _T_ then you get a simpler signature:

```c#
List<R> Diff<T, R> (IEnumerable<T> source, IEnumerable<T> destination,
                    Func<T, T, R> updateResult,
                    Func<T, R> addResult,
                    Func<T, R> removeResult,
                    out bool containsOnlyUpdates)
```

This uses [the default comparer (`EqualityComparer<T>.Default`)](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.equalitycomparer-1.default?view=netcore-3.1) so a function to determine a match isn't needed. This also solves the boxing/performance problem highlighted in issue #8.

Since we have tuples, we can go one step further for simpler scenarios with the following signature:

```c#
List<(A, S, D)> Diff<S, D, A> (IEnumerable<S> source, IEnumerable<D> destination,
                               Func<S, D, bool> match,
                               A update, A add, A remove,
                               out bool containsOnlyUpdates) =>
```

That is, given 3 tags to represent an update, add or remove node, the function will return a list of triplets where the source and destinations elements are annotated with the appropriate tag.

In its current design, the stand-alone `Diff` method is part of a class called `DiffModule`. This permits using the method directly via a static import (`using static ListDiff.DiffModule`).

I have also placed `DiffModule` in its own file and made the definition partial and private by default. Then in `ListDiff.cs`, the partial definition has the `public` modifier to make it public. The idea behind this seemingly bizarre approach is that it enables someone to just take `Diff.cs` and run with it in their project without inheriting any dependencies or types of the project. `DiffModule` will automatically become a private artifact of the user's project. However, when included together with `ListDiff.cs` as part of this project, it is exposed publicly.

If you like what you see here, I am happy to put polishing touches like doc comments and argument validation.

Looking forward to your review and thoughts.